### PR TITLE
Add feature for getEnum with default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ XPath helpers based on [XOM](http://www.xom.nu/ "XOM")
 <dependency>
 	<groupId>com.itelg</groupId>
 	<artifactId>xpath-helper</artifactId>
-	<version>0.5.0-RELEASE</version>
+	<version>0.5.1-RELEASE</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <name>xpath-helper</name>
   <description>XPath helpers based on Xom</description>
   <url>https://github.com/julian-eggers/xpath-helper</url>
-  <version>0.5.0-RELEASE</version>
+  <version>0.5.1-RELEASE</version>
 
   <properties>
     <!-- System -->
@@ -14,7 +14,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <!-- Testing -->
-    <jacoco.version>0.8.1</jacoco.version>
+    <jacoco.version>0.8.2</jacoco.version>
     <powermock.version>1.7.3</powermock.version>
     <easymock.version>3.6</easymock.version>
     <!-- Build -->
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
+      <version>3.8.1</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/com/itelg/xpath/helper/XPathHelper.java
+++ b/src/main/java/com/itelg/xpath/helper/XPathHelper.java
@@ -365,4 +365,16 @@ public class XPathHelper
 
         return null;
     }
+
+	public static <E extends Enum<E>> E getEnum(String xpath, Class<E> clazz, E defaultValue, Node node)
+	{
+		try
+		{
+			return getEnum(xpath, clazz, node);
+		}
+		catch (XPathValueConvertException e)
+		{
+			return defaultValue;
+		}
+	}
 }

--- a/src/test/java/com/itelg/xpath/helper/XPathHelperTest.java
+++ b/src/test/java/com/itelg/xpath/helper/XPathHelperTest.java
@@ -327,8 +327,31 @@ public class XPathHelperTest
         Assert.assertNull(XPathHelper.getEnum("enumNotConvertable", TestEnum.class, rootElement));
     }
 
+	@Test
+	public void testGetEnumOrDefault() throws Exception
+	{
+		Element rootElement = DocumentHelper.getRootElement(XmlLoader.loadXmlStream("valid.xml"));
+		assertEquals(TestEnum.DEFAULT,
+				XPathHelper.getEnum("enumNotConvertable", TestEnum.class, TestEnum.DEFAULT, rootElement));
+	}
+
+	@Test
+	public void testGetEnumWithEmpty() throws Exception
+	{
+		Element rootElement = DocumentHelper.getRootElement(XmlLoader.loadXmlStream("valid.xml"));
+		assertNull(XPathHelper.getEnum("enumEmpty", TestEnum.class, TestEnum.DEFAULT, rootElement));
+		assertNull(XPathHelper.getEnum("enumMissing", TestEnum.class, TestEnum.DEFAULT, rootElement));
+	}
+
+	@Test
+	public void testGetEnumWithKnownEnum() throws Exception
+	{
+		Element rootElement = DocumentHelper.getRootElement(XmlLoader.loadXmlStream("valid.xml"));
+		assertEquals(TestEnum.VALUE1, XPathHelper.getEnum("enum", TestEnum.class, TestEnum.DEFAULT, rootElement));
+	}
+
     private static enum TestEnum
     {
-        VALUE1;
+		VALUE1, DEFAULT;
     }
 }


### PR DESCRIPTION
If no existing enum could be mapped the defaultValue should be used.
If the tag does not exist null will be returned.

Resolves #11